### PR TITLE
Remove (very often nonexistent) remote repo for local builds

### DIFF
--- a/rpm/community-adaptation-localbuild.spec
+++ b/rpm/community-adaptation-localbuild.spec
@@ -1,7 +1,7 @@
-%define flavour devel
+%define flavour localbuild
 
 Conflicts: community-adaptation-testing
-Conflicts: community-adaptation-localbuild
+Conflicts: community-adaptation-devel
 
 %include rpm/community-adaptation.inc
 

--- a/rpm/community-adaptation-testing.spec
+++ b/rpm/community-adaptation-testing.spec
@@ -1,6 +1,7 @@
 %define flavour testing
 
 Conflicts: community-adaptation-devel
+Conflicts: community-adaptation-localbuild
 
 %include rpm/community-adaptation.inc
 

--- a/rpm/community-adaptation.inc
+++ b/rpm/community-adaptation.inc
@@ -16,22 +16,28 @@ Requires:	ssu
 
 %install
 
-%if "%{flavour}" != "devel"
+%if "%{flavour}" == "testing"
 touch $RPM_BUILD_ROOT/init_disable_telnet
 %endif
 
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/community-adaptation/
 
+%if "%{flavour}" != "localbuild"
 sed -e "s|@FLAVOUR@|%{flavour}|g" \
-%if "%{flavour}" == "devel"
+%if "%{flavour}" != "testing"
     -e "s|sailfishos_%%(release)|sailfish_latest_%%(arch)|g" \
 %endif
     adaptation-community.ini.in > $RPM_BUILD_ROOT/%{_datadir}/community-adaptation/adaptation-community.ini.in
+%else
+    touch $RPM_BUILD_ROOT/%{_datadir}/community-adaptation/adaptation-community.ini.in
+%endif
 
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/ssu/features.d/
 
-sed -e "s|@FLAVOUR@|%{flavour}|g" \
-%if "%{flavour}" == "devel"
+%if "%{flavour}" == "testing"
+sed -e "s|@FLAVOUR@|testing|g" \
+%else
+sed -e "s|@FLAVOUR@|devel|g" \
     -e "s|sailfishos_%%(release)|sailfish_latest_%%(arch)|g" \
 %endif
     adaptation-community-common.ini > $RPM_BUILD_ROOT/%{_datadir}/ssu/features.d/adaptation-community-common.ini


### PR DESCRIPTION
Most ports in early stages won't have OBS setup yet. This commit removes
adaptation-community repo that otherwise annoyingly pops up during repo ref.